### PR TITLE
collection should loaded one by one

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ Barrels.prototype.populate = function (collections, done, _options_) {
 
 	var that = this;
 
-	async.each(collections, _populate,
+	async.eachSeries(collections, _populate,
 		function (err) {
 			if (err)
 				return done(err);


### PR DESCRIPTION
it's need to avoid situation when required for association collection still loading, e.g. idMap already contains associatedModelName, but this one still empty.
